### PR TITLE
CON-390 Update all audit stack new version cloudcoreojsrunner.

### DIFF
--- a/services/config.rb
+++ b/services/config.rb
@@ -75,7 +75,7 @@ coreo_uni_util_variables "rds-planwide" do
             ])
 end
 
-coreo_aws_rule_runner_rds "advise-rds" do
+coreo_aws_rule_runner "advise-rds" do
   rules ${AUDIT_AWS_RDS_ALERT_LIST}
   action :run
   regions ${AUDIT_AWS_RDS_REGIONS}
@@ -84,8 +84,8 @@ end
 coreo_uni_util_variables "rds-update-planwide-1" do
   action :set
   variables([
-                {'COMPOSITE::coreo_uni_util_variables.rds-planwide.results' => 'COMPOSITE::coreo_aws_rule_runner_rds.advise-rds.report'},
-                {'COMPOSITE::coreo_uni_util_variables.rds-planwide.number_violations' => 'COMPOSITE::coreo_aws_rule_runner_rds.advise-rds.number_violations'},
+                {'COMPOSITE::coreo_uni_util_variables.rds-planwide.results' => 'COMPOSITE::coreo_aws_rule_runner.advise-rds.report'},
+                {'COMPOSITE::coreo_uni_util_variables.rds-planwide.number_violations' => 'COMPOSITE::coreo_aws_rule_runner.advise-rds.number_violations'},
 
             ])
 end
@@ -98,7 +98,7 @@ coreo_uni_util_jsrunner "tags-to-notifiers-array-rds" do
   packages([
                {
                    :name => "cloudcoreo-jsrunner-commons",
-                   :version => "1.8.3"
+                   :version => "*"
                },
                {
                    :name => "js-yaml",
@@ -107,7 +107,8 @@ coreo_uni_util_jsrunner "tags-to-notifiers-array-rds" do
                   ])
   json_input '{ "composite name":"PLAN::stack_name",
                 "plan name":"PLAN::name",
-                "violations": COMPOSITE::coreo_aws_rule_runner_rds.advise-rds.report}'
+                "cloud account name": "PLAN::cloud_account_name",
+                "violations": COMPOSITE::coreo_aws_rule_runner.advise-rds.report}'
   function <<-EOH
 
 
@@ -150,17 +151,18 @@ const ALLOW_EMPTY = "${AUDIT_AWS_RDS_ALLOW_EMPTY}";
 const SEND_ON = "${AUDIT_AWS_RDS_SEND_ON}";
 const SHOWN_NOT_SORTED_VIOLATIONS_COUNTER = false;
 
-const VARIABLES = { NO_OWNER_EMAIL, OWNER_TAG, 
+const SETTINGS = { NO_OWNER_EMAIL, OWNER_TAG, 
     ALLOW_EMPTY, SEND_ON, SHOWN_NOT_SORTED_VIOLATIONS_COUNTER};
 
 const CloudCoreoJSRunner = require('cloudcoreo-jsrunner-commons');
-const AuditRDS = new CloudCoreoJSRunner(JSON_INPUT, VARIABLES);
-const notifiers = AuditRDS.getNotifiers();
+const AuditRDS = new CloudCoreoJSRunner(JSON_INPUT, SETTINGS);
+const letters = AuditRDS.getLetters();
 
-const JSONReportAfterGeneratingSuppression = AuditRDS.getJSONForAuditPanel();
-coreoExport('JSONReport', JSON.stringify(JSONReportAfterGeneratingSuppression));
+const newJSONInput = AuditRDS.getSortedJSONForAuditPanel();
+coreoExport('JSONReport', JSON.stringify(newJSONInput));
+coreoExport('report', JSON.stringify(newJSONInput['violations']));
 
-callback(notifiers);
+callback(letters);
   EOH
 end
 
@@ -170,6 +172,7 @@ end
 coreo_uni_util_variables "rds-update-planwide-3" do
   action :set
   variables([
+                {'COMPOSITE::coreo_aws_rule_runner.advise-rds.report' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-rds.report'},
                 {'COMPOSITE::coreo_uni_util_variables.rds-planwide.results' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-rds.JSONReport'},
                 {'COMPOSITE::coreo_uni_util_variables.rds-planwide.table' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-rds.table'}
             ])

--- a/services/config.rb
+++ b/services/config.rb
@@ -75,7 +75,7 @@ coreo_uni_util_variables "rds-planwide" do
             ])
 end
 
-coreo_aws_rule_runner "advise-rds" do
+coreo_aws_rule_runner_rds "advise-rds" do
   rules ${AUDIT_AWS_RDS_ALERT_LIST}
   action :run
   regions ${AUDIT_AWS_RDS_REGIONS}
@@ -84,8 +84,8 @@ end
 coreo_uni_util_variables "rds-update-planwide-1" do
   action :set
   variables([
-                {'COMPOSITE::coreo_uni_util_variables.rds-planwide.results' => 'COMPOSITE::coreo_aws_rule_runner.advise-rds.report'},
-                {'COMPOSITE::coreo_uni_util_variables.rds-planwide.number_violations' => 'COMPOSITE::coreo_aws_rule_runner.advise-rds.number_violations'},
+                {'COMPOSITE::coreo_uni_util_variables.rds-planwide.results' => 'COMPOSITE::coreo_aws_rule_runner_rds.advise-rds.report'},
+                {'COMPOSITE::coreo_uni_util_variables.rds-planwide.number_violations' => 'COMPOSITE::coreo_aws_rule_runner_rds.advise-rds.number_violations'},
 
             ])
 end
@@ -108,7 +108,7 @@ coreo_uni_util_jsrunner "tags-to-notifiers-array-rds" do
   json_input '{ "composite name":"PLAN::stack_name",
                 "plan name":"PLAN::name",
                 "cloud account name": "PLAN::cloud_account_name",
-                "violations": COMPOSITE::coreo_aws_rule_runner.advise-rds.report}'
+                "violations": COMPOSITE::coreo_aws_rule_runner_rds.advise-rds.report}'
   function <<-EOH
 
 
@@ -172,7 +172,7 @@ end
 coreo_uni_util_variables "rds-update-planwide-3" do
   action :set
   variables([
-                {'COMPOSITE::coreo_aws_rule_runner.advise-rds.report' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-rds.report'},
+                {'COMPOSITE::coreo_aws_rule_runner_rds.advise-rds.report' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-rds.report'},
                 {'COMPOSITE::coreo_uni_util_variables.rds-planwide.results' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-rds.JSONReport'},
                 {'COMPOSITE::coreo_uni_util_variables.rds-planwide.table' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-rds.table'}
             ])


### PR DESCRIPTION
PLA-3163 Engine does not support empty rules array
CON-287 Audit reports in WebUI and email don't list which AWS account being run on
CON-318 display meta_ attributes on cards
CON-334 add notifiers and jsrunner structures to the AWS config composite
CON-376 Report Emails: Update '# Resources' on cards to '# Cloud Objects'

Please note that this engine fix (https://bitbucket.org/cloudcoreo/engine/pull-requests/471) was merged only to master branch. If you run audit composites on the engine's dev branch it will give you the following error: "There's no rule named '' defined". So I guess we need to merge this fix to dev branch also. In master branch audit composites run correctly.